### PR TITLE
If WP_TEMP_DIR is set use it

### DIFF
--- a/src/includes/closures/Shared/FsUtils.php
+++ b/src/includes/closures/Shared/FsUtils.php
@@ -52,7 +52,7 @@ $self->getTmpDir = function () use ($self) {
     $possible_dirs = array(); // Initialize.
 
     if (defined('WP_TEMP_DIR')) {
-        $possible_dirs[] = (string) WP_TEMP_DIR;
+        return (string) WP_TEMP_DIR;
     }
     if ($self->functionIsPossible('sys_get_temp_dir')) {
         $possible_dirs[] = (string) sys_get_temp_dir();


### PR DESCRIPTION
When Zencache tries to guess the path to the tmp-diretory, on IIS Win2008R2 with strict open_basedir enabled, it returns a non-writable directory. It seems the PHP function is_writables() is reporting the directories to be writable even it's outside the the paths specified in open_basedir().

Tried to manually set the dir with WP_TEMP_DIR, but since it's guessing on the other possible directories seems to interfere and report success before the WP_TEMP_DIR is tested.

If a user explicit sets WP_TEMP_DIR (and propably knows what he/she is doing) I propose that this should be used. Alternative use a special constant for Zencart.
